### PR TITLE
JAT 0026

### DIFF
--- a/liferay/helpers_jira.py
+++ b/liferay/helpers_jira.py
@@ -159,9 +159,12 @@ def prepare_test_validation_subtask(story):
 def read_test_cases_table_from_description(description):
     table_starring_string = '||Test Scenarios||'
     table_ending_string = 'h3. Test Cases'
+    table_alternative_ending_string = '*Case '
     table_staring_position = description.find(table_starring_string)
     table_ending_position = description.find(table_ending_string)
     if table_staring_position != -1:
+        if table_ending_position == -1:
+            table_ending_position = description.find(table_alternative_ending_string)
         table = description[table_staring_position:table_ending_position]
         table_rows = table.split('\r\n')
         table_rows = [value for value in table_rows if value != '']


### PR DESCRIPTION
- JAT-0025 Improve messages
- JAT-0025 Fix error when first component doesn't belong to the team
- JAT-0025 Fix error when a bug didn't have FP
- JAT-0025 Take only team components
- JAT-0025 Take only team components
- JAT-0026 Fix error when test was low priority and was not automated
- JAT-0026 Fix error when table was not followed by Test Case title
