### PR TITLE
JAT 0033

### DIFF
--- a/liferay/echo_test_map.py
+++ b/liferay/echo_test_map.py
@@ -21,6 +21,8 @@ ECHO_TESTMAP_SHEET_LAST_COLUMN = 'Q'
 ECHO_TESTMAP_SHEET_COMPONENT_COLUMN = 'I'
 ECHO_TESTMAP_SHEET_HEADER_LENGTH = 2
 ECHO_TESTMAP_SHEET_FIRST_COLUMN_NUMBER = ECHO_TESTMAP_SHEET_HEADER_LENGTH + 1
+JIRA_TEST_MAP_TAB = "JIRA-TestMap"
+JIRA_TEST_MAP_TAB_RANGE = JIRA_TEST_MAP_TAB + '!B3:H'
 OUTPUT_MESSAGE_FILE_NAME = "output_message.txt"
 OUTPUT_INFO_FILE_NAME = "output_info.txt"
 OUTPUT_BUG_THRESHOLD_EXCEED_FILE_NAME = "bug_threshold_exceed_message.txt"
@@ -235,6 +237,11 @@ def check_need_automation_test_cases(sheet, jira, echo_team_components, output_w
                                    "|" + story.key + "> is still not automated\n "
 
     return output_warning, output_info
+
+
+def update_echo_test_map(sheet, jira, output_info):
+    output_info = update_test_map(sheet, jira, output_info, 'filter=49998', ECHO_TESTMAP_ID, JIRA_TEST_MAP_TAB_RANGE)
+    return output_info
 
 
 if __name__ == "__main__":

--- a/liferay/echo_test_map.py
+++ b/liferay/echo_test_map.py
@@ -2,12 +2,9 @@
 from collections import Counter
 
 from helpers import create_output_files
-from helpers_google_sheet import expand_group, collapse_group
-from helpers_jira import read_test_cases_table_from_description, LIFERAY_JIRA_BROWSE_URL, LIFERAY_JIRA_ISSUES_URL, \
-    get_team_components
+from helpers_jira import *
 from jira_liferay import get_jira_connection
-from helpers_testmap import is_mapped, get_mapped_stories, insert_lines_in_component, remove_underline, update_line, \
-    get_group_start_and_end_position, get_component
+from helpers_testmap import *
 from testmap_jira import get_testmap_connection
 
 CONTROL_PANEL_SHEET_NAME = 'Control panel'
@@ -89,7 +86,7 @@ def add_test_cases_to_test_map(sheet, jira, echo_team_components, output_warning
         if not is_mapped(story.key, lps_list):
             print("Processing ", story.key)
             labels = story.get_field("labels")
-            story_component = get_component(story, echo_team_components)
+            story_component = get_component_in_team_components(story, echo_team_components)
             if not story_component:
                 output_warning += "* Story <" + LIFERAY_JIRA_BROWSE_URL + story.key + \
                                   "|" + story.key + "> has a component or components that do not belong to the team\n "
@@ -204,7 +201,7 @@ def check_need_automation_test_cases(sheet, jira, echo_team_components, output_w
         'values', [])
     for lps in lps_list:
         story = jira.issue(lps[0])
-        component = get_component(story, echo_team_components)
+        component = get_component_in_team_components(story, echo_team_components)
         if not component:
             output_warning += "* Story <" + LIFERAY_JIRA_BROWSE_URL + story.key + \
                            "|" + story.key + "> has a component or components that do not belong to the team\n "

--- a/liferay/echo_test_map.py
+++ b/liferay/echo_test_map.py
@@ -111,7 +111,7 @@ def add_test_cases_to_test_map(sheet, jira, echo_team_components, output_warning
                                                'Automated', test_case_list[7], test_case_list[8], '', '',
                                                test_case_list[4], test_case_list[5]))
                             _add_lines_to_components_dic(components_testcases_dict, story_component, lines)
-                            output_info += "* Added tests for story <" + LIFERAY_JIRA_BROWSE_URL + story.key +\
+                            output_info += "* Added tests for story <" + LIFERAY_JIRA_BROWSE_URL + story.key + \
                                            "|" + story.key + ">: Poshi finished\n"
                         else:
                             test_cases_table = read_test_cases_table_from_description(story.fields.description)
@@ -177,7 +177,7 @@ def check_bug_threshold(sheet, jira, output_exceed, output_warning):
                 output_exceed += '* Bug threshold exceed for <' + LIFERAY_JIRA_ISSUES_URL + '?filter=' + \
                                  filter_id[0] + "|" + current_component_group + '> in Fix Priority ' + str(fp) + '\n'
             elif max_value != 0 and current_bug_numbers == max_value:
-                output_warning += '* Bug threshold just on the limit for <' + LIFERAY_JIRA_ISSUES_URL + '?filter=' +\
+                output_warning += '* Bug threshold just on the limit for <' + LIFERAY_JIRA_ISSUES_URL + '?filter=' + \
                                   filter_id[0] + "|" + current_component_group + '> in Fix Priority ' + str(fp) + '\n'
 
     return output_exceed, output_warning
@@ -204,7 +204,7 @@ def check_need_automation_test_cases(sheet, jira, echo_team_components, output_w
         component = get_component_in_team_components(story, echo_team_components)
         if not component:
             output_warning += "* Story <" + LIFERAY_JIRA_BROWSE_URL + story.key + \
-                           "|" + story.key + "> has a component or components that do not belong to the team\n "
+                              "|" + story.key + "> has a component or components that do not belong to the team\n "
             continue
         for link in story.fields.issuelinks:
             linked_issue_key = ""

--- a/liferay/helpers_jira.py
+++ b/liferay/helpers_jira.py
@@ -56,6 +56,19 @@ def create_poshi_automation_task_for(jira_local, issue, summary, description):
     return new_issue
 
 
+def get_all_issues(jira_local, jql_str, fields):
+    issues = []
+    i = 0
+    chunk_size = 50
+    while True:
+        chunk = jira_local.search_issues(jql_str, startAt=i, maxResults=chunk_size, fields=fields)
+        i += chunk_size
+        issues += chunk.iterable
+        if i >= chunk.total:
+            break
+    return issues
+
+
 def create_poshi_automation_task_for_bug(jira_local, bug):
     parent_key = bug.key
     bug_summary = bug.fields.summary

--- a/liferay/helpers_testmap.py
+++ b/liferay/helpers_testmap.py
@@ -1,6 +1,7 @@
 from itertools import islice
 
 from helpers_google_sheet import *
+from helpers_jira import get_all_issues
 
 
 def component_row(component, matrix):

--- a/liferay/helpers_testmap.py
+++ b/liferay/helpers_testmap.py
@@ -12,7 +12,11 @@ def component_row(component, matrix):
     return position
 
 
-def get_component(story, team_components):
+def get_components(story):
+    return [component.name for component in story.get_field("components")]
+
+
+def get_component_in_team_components(story, team_components):
     components = story.get_field("components")
     for component in components:
         if component.name in team_components:

--- a/test/test_echo_test_map.py
+++ b/test/test_echo_test_map.py
@@ -50,6 +50,15 @@ class EchoTestMapTests(unittest.TestCase):
         except Exception:
             self.fail("Test failed unexpectedly!")
 
+    def test_echo_update_test_map(self):
+        try:
+            info_test = ''
+            jira_connection_test = get_jira_connection()
+            sheet_connection_test = get_testmap_connection()
+            info_test = update_echo_test_map(sheet_connection_test, jira_connection_test, info_test)
+        except Exception:
+            self.fail("Test failed unexpectedly!")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_echo_test_map.py
+++ b/test/test_echo_test_map.py
@@ -1,7 +1,6 @@
 import unittest
 
-from echo_test_map import add_test_cases_to_test_map, check_need_automation_test_cases, check_control_panel_tab, \
-    check_bug_threshold
+from echo_test_map import *
 from helpers_jira import get_team_components
 from jira_liferay import get_jira_connection
 from testmap_jira import get_testmap_connection
@@ -11,22 +10,23 @@ class EchoTestMapTests(unittest.TestCase):
     def test_add_test_cases_to_test_map(self):
         try:
             message = ''
-            info = ''
-            jira_connection = get_jira_connection()
-            sheet_connection = get_testmap_connection()
-            team_components = get_team_components(jira_connection, 'LPS', 'Product Team Echo')
-            message, info = add_test_cases_to_test_map(sheet_connection, jira_connection, team_components,
-                                                       message, info)
+            info_test = ''
+            jira_connection_test = get_jira_connection()
+            sheet_connection_test = get_testmap_connection()
+            team_components_test = get_team_components(jira_connection, 'LPS', 'Product Team Echo')
+            message, info_test = add_test_cases_to_test_map(sheet_connection_test, jira_connection_test,
+                                                            team_components_test,
+                                                            message, info_test)
         except Exception:
             self.fail("Test failed unexpectedly!")
 
     def test_check_bug_threshold(self):
         try:
             message = ''
-            info = ''
-            jira_connection = get_jira_connection()
-            sheet_connection = get_testmap_connection()
-            message, info = check_bug_threshold(sheet_connection, jira_connection, message, info)
+            info_test = ''
+            jira_connection_test = get_jira_connection()
+            sheet_connection_test = get_testmap_connection()
+            message, info_test = check_bug_threshold(sheet_connection_test, jira_connection_test, message, info_test)
         except Exception:
             self.fail("Test failed unexpectedly!")
 
@@ -41,12 +41,12 @@ class EchoTestMapTests(unittest.TestCase):
     def test_check_need_automation_test_cases(self):
         try:
             message = ''
-            info = ''
-            jira_connection = get_jira_connection()
-            sheet_connection = get_testmap_connection()
-            team_components = get_team_components(jira_connection, 'LPS', 'Product Team Echo')
-            message, info = check_need_automation_test_cases(sheet_connection, jira_connection, team_components,
-                                                             message, info)
+            info_test = ''
+            jira_connection_test = get_jira_connection()
+            sheet_connection_test = get_testmap_connection()
+            team_components_test = get_team_components(jira_connection_test, 'LPS', 'Product Team Echo')
+            message, info_test = check_need_automation_test_cases(sheet_connection_test, jira_connection,
+                                                                  team_components_test, message, info_test)
         except Exception:
             self.fail("Test failed unexpectedly!")
 


### PR DESCRIPTION
- JAT-0025 Improve messages
- JAT-0025 Fix error when first component doesn't belong to the team
- JAT-0025 Fix error when a bug didn't have FP
- JAT-0025 Take only team components
- JAT-0025 Take only team components
- JAT-0026 Fix error when test was low priority and was not automated
- JAT-0026 Fix error when table was not followed by Test Case title
- Changes in headless script
- Adding another case to update_validation_subtask if
- JAT-0026 Fix error when test was low priority and was not automated
- JAT-0026 Fix error when table was not followed by Test Case title
- JAT-0027 Fix list index out of range error
- Headless.py - generalise rule for Validation task
- JAT-0028 To add component Segment for bug threshold verification
- JAT-0028 Fix bug when inserting on last component
- JAT-0032 Add missing colum when case don't need automation
- JAT-0033 To add method to fill round technical testing description
- JAT-0033 Include method fill_round_technical_testing_description to be executed
- JAT-0033 Create test for fill_round_technical_testing_description
- JAT-0033 Add get_all_issues
- JAT-0033 Add new get_components method
- JAT-0033 Source format
- JAT-0033 Refactor test cases
- JAT-0033 New method to update test map
- JAT-0033 New method to update test map for Echo team
- JAT-0033 Add missing import
- JAT-0033 Add test for test_echo_update_test_map
