### PR TITLE
JAT 0034

### DIFF
--- a/liferay/frontend_infrastructure.py
+++ b/liferay/frontend_infrastructure.py
@@ -149,5 +149,6 @@ if __name__ == "__main__":
     info = create_test_creation_subtask(jira_connection, info)
     info = create_test_validation_subtask(jira_connection, info)
     info = create_poshi_automation_task(jira_connection, info)
+    create_technical_sub_task_test_scope_out_of_scope_creation(jira_connection, info)
 
     create_output_files([warning, OUTPUT_MESSAGE_FILE_NAME], [info, OUTPUT_INFO_FILE_NAME])

--- a/liferay/frontend_infrastructure.py
+++ b/liferay/frontend_infrastructure.py
@@ -125,7 +125,21 @@ def create_poshi_automation_task(jira, output_info):
     output_info += "✓ Poshi automation tasks are up to date \n"
     return output_info
 
-    print("✓ Poshi automation tasks are up to date \n")
+
+def create_technical_sub_task_test_scope_out_of_scope_creation(jira, output_info):
+    issues_to_update = jira.search_issues('filter=56504', fields="key, components")
+    summary = "Test Scenarios Coverage | Test Scope/out of Scope Creation"
+    description = ""
+    for story in issues_to_update:
+        components = []
+        for component in story.fields.components:
+            components.append({'name': component.name})
+        subtask_fields = __initialize_subtask_technical_test(story, components, summary, description)
+        child = jira.create_issue(fields=subtask_fields)
+        output_info += "   * sub-task created " + child.key + " created for story " + story.key
+        jira.assign_issue(child.id, QA_JIRA_USER)
+
+    return output_info
 
 
 if __name__ == "__main__":

--- a/liferay/frontend_infrastructure.py
+++ b/liferay/frontend_infrastructure.py
@@ -4,6 +4,7 @@ from helpers_jira import *
 from helpers_jira import __initialize_subtask_technical_test
 from jira_liferay import get_jira_connection
 
+QA_JIRA_USER = 'carlos.brichete'
 OUTPUT_MESSAGE_FILE_NAME = "output_message.txt"
 OUTPUT_INFO_FILE_NAME = "output_info.txt"
 
@@ -128,8 +129,11 @@ def create_poshi_automation_task(jira, output_info):
 
 
 if __name__ == "__main__":
+    warning = ''
+    info = ''
     jira_connection = get_jira_connection()
-    print("Creating subtasks for Frontend Infra team...\n")
-    create_test_creation_subtask(jira_connection)
-    create_test_validation_subtask(jira_connection)
-    create_poshi_automation_task(jira_connection)
+    info = create_test_creation_subtask(jira_connection, info)
+    info = create_test_validation_subtask(jira_connection, info)
+    info = create_poshi_automation_task(jira_connection, info)
+
+    create_output_files([warning, OUTPUT_MESSAGE_FILE_NAME], [info, OUTPUT_INFO_FILE_NAME])

--- a/test/test_frontend_infranstructure.py
+++ b/test/test_frontend_infranstructure.py
@@ -1,0 +1,19 @@
+import unittest
+
+from frontend_infrastructure import *
+from jira_liferay import get_jira_connection
+
+
+class EchoTestMapTests(unittest.TestCase):
+
+    def test_create_technical_sub_task_test_scope_out_of_scope_creation(self):
+        try:
+            info_test = ''
+            jira_connection_test = get_jira_connection()
+            info_test = create_technical_sub_task_test_scope_out_of_scope_creation(jira_connection_test, info_test)
+        except Exception:
+            self.fail("Test failed unexpectedly!")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- JAT-0025 Improve messages
- JAT-0025 Fix error when first component doesn't belong to the team
- JAT-0025 Fix error when a bug didn't have FP
- JAT-0025 Take only team components
- JAT-0025 Take only team components
- JAT-0026 Fix error when test was low priority and was not automated
- JAT-0026 Fix error when table was not followed by Test Case title
- Changes in headless script
- Adding another case to update_validation_subtask if
- JAT-0026 Fix error when test was low priority and was not automated
- JAT-0026 Fix error when table was not followed by Test Case title
- JAT-0027 Fix list index out of range error
- Headless.py - generalise rule for Validation task
- JAT-0028 To add component Segment for bug threshold verification
- JAT-0028 Fix bug when inserting on last component
- JAT-0032 Add missing colum when case don't need automation
- JAT-0033 To add method to fill round technical testing description
- JAT-0033 Include method fill_round_technical_testing_description to be executed
- JAT-0033 Create test for fill_round_technical_testing_description
- JAT-0033 Add get_all_issues
- JAT-0033 Add new get_components method
- JAT-0033 Source format
- JAT-0033 Refactor test cases
- JAT-0033 New method to update test map
- JAT-0033 New method to update test map for Echo team
- JAT-0033 Add missing import
- JAT-0033 Add test for test_echo_update_test_map
- JAT-0033 Add updated time info
- JAT-0033 Add update_echo_test_map to be executed
- JAT-0033 Add update_frontend_infra_test_map
- JAT-0033 Add test for update_frontend_infra_test_map
- JAT-0033 Add output_info.txt to .gitignore
- JAT-0034 Prepare functions out put info
- JAT-0034 Set output info into file
- JAT-0034 New method to create technical task about out of scope
- JAT-0034 Use new method to create technical task about out of scope
- JAT-0034 Add test for new method
