### PR TITLE
JAT 0069 Control error when sub task can not be closed

### DIFF
--- a/liferay/teams/echo/echo.py
+++ b/liferay/teams/echo/echo.py
@@ -185,8 +185,9 @@ def create_poshi_automation_task(jira, output_warning, output_info):
                                    html_issue_with_link(story) + "\n "
                     close_functional_automation_subtask(jira, story)
             except JIRAError as err:
-                output_warning += "It was not possible to close automation sub-task or create automation external " \
-                                  "task for story " + story.key + ". Please do it manually. \n    Trace: \n" + str(err)
+                output_warning += "[ERROR] It was not possible to close automation sub-task or create automation " \
+                                  "external task for story " + story.key + ". Please do it manually. \n    Trace: \n"\
+                                  + str(err)
         else:
             output_warning += "Story " + story.key + " don't have test table. \n"
 

--- a/liferay/teams/echo/echo.py
+++ b/liferay/teams/echo/echo.py
@@ -173,7 +173,10 @@ def create_poshi_automation_task(jira, output_warning, output_info):
                 if is_automation_task_needed:
                     poshi_task = _create_poshi_task_for_story(jira, story, poshi_automation_table)
                     output_info += "* Automation task created for story " + html_issue_with_link(story) + "\n "
-                    close_functional_automation_subtask(jira, story, poshi_task.key)
+                    if not poshi_task:
+                        close_functional_automation_subtask(jira, story, ' in the testing task linked in the story.')
+                    else:
+                        close_functional_automation_subtask(jira, story, poshi_task.key)
                 else:
                     jira.add_comment(story, "No Poshi automation is needed.")
                     story.fields.labels.append("poshi_test_not_needed")


### PR DESCRIPTION
- JAT-0069 Don't create automation task if it already exists
- JAT-0069 Control error when automation task can not be created
- JAT-0069 Optimize the way of compose warning messages
- JAT-0069 Move message to same line
- JAT-0069 Control error message when automation task already exist
- JAT-0069 Add error word to output message
